### PR TITLE
Added code of conduct & contributing

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,2 +1,1 @@
-Hello Contributors, If you have any questions regarding the Code Collabo community's code of conduct. 
-You can find them here: https://code-collabo.gitbook.io/collabo-contributor/collabo-contributor-docs/code-of-conduct
+Hello Contributors, You can find the community code of conduct in the contributor docs section of the Code Collabo Community and projects documentation here: https://code-collabo.gitbook.io/collabo-contributor/collabo-contributor-docs/code-of-conduct

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,2 @@
+Hello Contributors, If you have any questions regarding the Code Collabo community's code of conduct. 
+You can find them here: https://code-collabo.gitbook.io/collabo-contributor/collabo-contributor-docs/code-of-conduct

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,1 @@
+Hello Contributors, You can find the community contributing guide in the contributor docs section of the Code Collabo Community and projects documentation here: https://code-collabo.gitbook.io/docs/collabo-docs-home/readme


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes code-collabo/put-repo-name-where-the-issue-is-located-here#24


**Testing checklist**

-  [x] Code of conduct has been added for node-mongo repo. The content lets contributors know that they can find the community code of conduct in the contributor docs section of the [Code Collabo Community and projects documentation](https://code-collabo.gitbook.io/collabo-contributor/collabo-contributor-docs/code-of-conduct).

- [x] contributing has been added for node-mongo doc repo. The content lets contributors know that they can find the community contributing guide in the contributor docs section of the [Code Collabo Community and projects documentation](https://code-collabo.gitbook.io/docs/collabo-docs-home/readme).

- [x] I certify that I ran my checklist

Ping @code-collabo/node-mongo
